### PR TITLE
Fix edge prediction observed-graph protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,14 @@ For example, to run the EDHNN method on the Pubmed dataset for a hyperedge predi
 python main.py --dname=pubmed --task_type=edge_pred --method=EDHNN --is_default=True
 ```
 
+By default, `edge_pred` uses the original DHG-Bench protocol for backward compatibility. To evaluate a held-out hyperedge prediction protocol where validation/test target hyperedges are removed from the message-passing hypergraph, use:
+
+```bash
+python main.py --dname=pubmed --task_type=edge_pred --method=EDHNN --is_default=True --edge_pred_protocol=observed
+```
+
+In `--edge_pred_protocol=observed`, DHG-Bench builds node embeddings on the observed/support hypergraph only, evaluates separate train/validation/test positive hyperedges, and samples negatives while excluding all true hyperedges. This avoids structural leakage from held-out hyperedges and fixes validation positives to use the validation target set rather than training positives.
+
 For example, to run the TFHNN method on the stream_player dataset for a hypergraph classification task, use the following command:
 
 ```bash

--- a/dhgbench/lib_dataset/edge_loaders.py
+++ b/dhgbench/lib_dataset/edge_loaders.py
@@ -1,5 +1,6 @@
 import os
 import random
+import copy
 import torch
 import numpy as np
 from lib_utils.utils import fix_seed
@@ -8,6 +9,42 @@ from lib_dataset.edge_sampler import *
 import torch
 import numpy as np
 from collections import defaultdict
+
+def hyperedges_from_data(data):
+    hyperedge_index = data.hyperedge_index.to('cpu')
+    hyperedges = defaultdict(set)
+
+    for node, edge in zip(*hyperedge_index.tolist()):
+        hyperedges[edge].add(node)
+
+    return [frozenset(nodes) for nodes in hyperedges.values()]
+
+def hyperedges_to_index(hyperedges, device):
+    node_ids = []
+    edge_ids = []
+    for edge_id, edge in enumerate(hyperedges):
+        for node in edge:
+            node_ids.append(int(node))
+            edge_ids.append(edge_id)
+    if len(node_ids) == 0:
+        return torch.empty((2, 0), dtype=torch.long, device=device)
+    return torch.tensor([node_ids, edge_ids], dtype=torch.long, device=device)
+
+def build_observed_support_data(data, data_dict, args):
+    support_data = copy.deepcopy(data)
+    support_hyperedges = [frozenset(edge) for edge in data_dict.get("support_pos", [])]
+    support_hyperedge_index = hyperedges_to_index(support_hyperedges, args.device)
+
+    support_data.hyperedge_index = support_hyperedge_index
+    support_data.num_hyperedges = len(support_hyperedges)
+    support_data.norm = torch.ones_like(support_hyperedge_index[0])
+
+    if hasattr(support_data, "data"):
+        support_data.data.edge_index = support_hyperedge_index.detach().cpu()
+        support_data.data.num_hyperedges = torch.tensor([len(support_hyperedges)])
+        support_data.data.norm = torch.ones_like(support_data.data.edge_index[0])
+
+    return support_data
 
 def generate_ind_split_hyperedges(data, args, seed):
     """
@@ -77,6 +114,65 @@ def generate_ind_split_hyperedges(data, args, seed):
     'valid_only_pos': valid_only_data, 'valid_mns': valid_mns, 'valid_sns' : valid_sns, 'valid_cns' : valid_cns, \
     'test_pos': test_data, 'test_mns': test_mns, 'test_sns' : test_sns, 'test_cns' : test_cns},
     f'./lib_edge_splits/{args.edge_split_mode}/{args.dname}/split_{seed}.pt')
+
+def generate_observed_ind_split_hyperedges(data, args, seed):
+    HE = hyperedges_from_data(data)
+
+    ratio = (args.train_prop, args.valid_prop, 1 - args.train_prop - args.valid_prop)
+
+    seed_base = 42
+    fix_seed(seed_base+seed)
+
+    all_nodes = set()
+    for e in HE:
+        all_nodes |= e
+    all_nodes = list(all_nodes)
+    np.random.shuffle(all_nodes)
+
+    N = len(all_nodes)
+    r1, r2, r3 = ratio
+
+    T1 = int(N * r1)
+    T2 = int(N * (r1 + r2))
+
+    train_nodes = set(all_nodes[:T1])
+    valid_nodes = set(all_nodes[T1:T2])
+    test_nodes  = set(all_nodes[T2:])
+
+    GP_train = []
+    GP_valid = []
+    GP_test  = []
+
+    for e in HE:
+        if e.issubset(train_nodes):
+            GP_train.append(e)
+        elif e.issubset(valid_nodes):
+            GP_valid.append(e)
+        elif e.issubset(test_nodes):
+            GP_test.append(e)
+
+    train_size, valid_size, test_size = len(GP_train), len(GP_valid), len(GP_test)
+
+    print(f'train_size: {train_size}, valid_size: {valid_size}, test_size: {test_size}')
+
+    all_positive_hyperedges = set(HE)
+    train_mns, train_sns, train_cns = neg_generator_excluding(GP_train, train_size, all_positive_hyperedges)
+    valid_mns, valid_sns, valid_cns = neg_generator_excluding(GP_train + GP_valid, valid_size, all_positive_hyperedges)
+    test_mns, test_sns, test_cns = neg_generator_excluding(GP_train + GP_valid, test_size, all_positive_hyperedges)
+
+    ground_train_data = []
+    ground_valid_data = []
+    train_only_data = [list(edge) for edge in GP_train]
+    valid_only_data = [list(edge) for edge in GP_valid]
+    test_data = [list(edge) for edge in GP_test]
+    support_data = [list(edge) for edge in GP_train]
+
+    torch.save({'edge_pred_protocol': 'observed', 'support_pos': support_data,
+    'ground_train': ground_train_data, 'ground_valid': ground_valid_data, \
+    'train_only_pos': train_only_data, 'train_mns': train_mns, 'train_sns' : train_sns, 'train_cns' : train_cns,\
+    'valid_only_pos': valid_only_data, 'valid_mns': valid_mns, 'valid_sns' : valid_sns, 'valid_cns' : valid_cns, \
+    'test_pos': test_data, 'test_mns': test_mns, 'test_sns' : test_sns, 'test_cns' : test_cns},
+    f'{args.edge_save_dir}{args.edge_split_mode}_{args.edge_pred_protocol}/{args.dname}/split_{seed}.pt')
 
 def generate_split_hyperedges(data,args,seed):
 
@@ -160,6 +256,80 @@ def generate_split_hyperedges(data,args,seed):
         'test_pos': test_data, 'test_mns': test_mns, 'test_sns' : test_sns, 'test_cns' : test_cns},
         f'./lib_edge_splits/{args.edge_split_mode}/{args.dname}/split_{seed}.pt')
 
+def generate_observed_split_hyperedges(data,args,seed):
+
+    HE = hyperedges_from_data(data)
+
+    base_cover = get_cover_idx(HE)
+    union = get_union(HE)
+    tmp = [HE[idx] for idx in base_cover]
+    assert union == get_union(tmp)
+    base_num = len(base_cover)
+
+    os.makedirs(f'{args.edge_save_dir}{args.edge_split_mode}_{args.edge_pred_protocol}/{args.dname}', exist_ok=True)
+
+    seed_base = 42
+    fix_seed(seed_base+seed)
+
+    ground_num = max(int(0.6*len(HE)) - base_num,0)
+    total_idx = list(range(len(HE)))
+    ground_idx = list(set(total_idx)-set(base_cover))
+    ground_idx = random.sample(ground_idx, ground_num)
+    ground_num += base_num
+    ground_idx += base_cover
+    ground_valid_num = ground_num//6
+    ground_valid_idx = random.sample(ground_idx, ground_valid_num)
+    ground_train_num = ground_num - ground_valid_num
+
+    ground_train_data = []
+    ground_valid_data = []
+    pred_data = []
+    for idx in total_idx :
+        if idx in ground_idx:
+            if idx in ground_valid_idx:
+                ground_valid_data.append(HE[idx])
+            else:
+                ground_train_data.append(HE[idx])
+        else :
+            pred_data.append(HE[idx])
+
+    valid_only_num = int(0.25*len(pred_data))
+    train_only_num = int(0.25*len(pred_data))
+    test_num = len(pred_data) - (valid_only_num + train_only_num)
+
+    random.shuffle(pred_data)
+    train_only_data = pred_data[:train_only_num]
+    valid_only_data = pred_data[train_only_num:-test_num]
+    test_data = pred_data[-test_num:]
+
+    all_positive_hyperedges = set(HE)
+    GP_train = ground_train_data + train_only_data
+    GP_valid = ground_train_data + train_only_data + ground_valid_data + valid_only_data
+    GP_test = GP_valid
+
+    train_mns, train_sns, train_cns = neg_generator_excluding(GP_train, train_only_num, all_positive_hyperedges)
+    valid_mns, valid_sns, valid_cns = neg_generator_excluding(GP_valid, ground_valid_num+valid_only_num, all_positive_hyperedges)
+    test_mns, test_sns, test_cns = neg_generator_excluding(GP_test, test_num, all_positive_hyperedges)
+
+    support_data = [list(edge) for edge in ground_train_data]
+    ground_train_data = [list(edge) for edge in ground_train_data]
+    ground_valid_data = [list(edge) for edge in ground_valid_data]
+    train_only_data = [list(edge) for edge in train_only_data]
+    valid_only_data = [list(edge) for edge in valid_only_data]
+    test_data = [list(edge) for edge in test_data]
+
+    print(f"support {len(support_data)}")
+    print(f"train pos {len(train_only_data)}, neg {len(train_mns)}")
+    print(f"valid pos {len(ground_valid_data)} + {len(valid_only_data)} = {len(ground_valid_data + valid_only_data)}, neg {len(valid_mns)}")
+    print(f"test pos {len(test_data)}, neg {len(test_mns)}")
+
+    torch.save({'edge_pred_protocol': 'observed', 'support_pos': support_data,
+        'ground_train': ground_train_data, 'ground_valid': ground_valid_data, \
+        'train_only_pos': train_only_data, 'train_mns': train_mns, 'train_sns' : train_sns, 'train_cns' : train_cns,\
+        'valid_only_pos': valid_only_data, 'valid_mns': valid_mns, 'valid_sns' : valid_sns, 'valid_cns' : valid_cns, \
+        'test_pos': test_data, 'test_mns': test_mns, 'test_sns' : test_sns, 'test_cns' : test_cns},
+        f'{args.edge_save_dir}{args.edge_split_mode}_{args.edge_pred_protocol}/{args.dname}/split_{seed}.pt')
+
 def generate_edge_loaders(data_dict, args):
 
     device = args.device
@@ -194,7 +364,10 @@ def generate_edge_loaders(data_dict, args):
 
 def load_train(data_dict, bs, device, label):
     if label=="pos":
-        train_pos = data_dict["train_only_pos"] + data_dict["ground_train"]
+        if data_dict.get("edge_pred_protocol") == "observed":
+            train_pos = data_dict["train_only_pos"]
+        else:
+            train_pos = data_dict["train_only_pos"] + data_dict["ground_train"]
         train_pos_label = [1 for i in range(len(train_pos))]
         train_batchloader = HEBatchGenerator(train_pos, train_pos_label, bs, device, test_generator=False) 
     elif label =="mixed":
@@ -211,7 +384,10 @@ def load_train(data_dict, bs, device, label):
 
 def load_val(data_dict, bs, device, label):
     if label=="pos":
-        val = data_dict["train_only_pos"] + data_dict["ground_train"]
+        if data_dict.get("edge_pred_protocol") == "observed":
+            val = data_dict["ground_valid"] + data_dict["valid_only_pos"]
+        else:
+            val = data_dict["train_only_pos"] + data_dict["ground_train"]
         val_label = [1 for i in range(len(val))]
     else:
         val = data_dict[f"valid_{label}"]

--- a/dhgbench/lib_dataset/edge_loaders.py
+++ b/dhgbench/lib_dataset/edge_loaders.py
@@ -17,7 +17,20 @@ def hyperedges_from_data(data):
     for node, edge in zip(*hyperedge_index.tolist()):
         hyperedges[edge].add(node)
 
-    return [frozenset(nodes) for nodes in hyperedges.values()]
+    return deduplicate_hyperedges(hyperedges.values())
+
+def deduplicate_hyperedges(hyperedges):
+    unique_hyperedges = []
+    seen = set()
+
+    for edge in hyperedges:
+        canonical_edge = frozenset(int(node) for node in edge)
+        if canonical_edge in seen:
+            continue
+        seen.add(canonical_edge)
+        unique_hyperedges.append(canonical_edge)
+
+    return unique_hyperedges
 
 def hyperedges_to_index(hyperedges, device):
     node_ids = []
@@ -52,14 +65,7 @@ def generate_ind_split_hyperedges(data, args, seed):
     ratio: train/val/test node ratio
     """
 
-    hyperedge_index = data.hyperedge_index.to('cpu')
-
-    hyperedges = defaultdict(set)
-
-    for node, edge in zip(*hyperedge_index.tolist()):
-        hyperedges[edge].add(node)
-
-    hyperedges = [frozenset(nodes) for nodes in hyperedges.values()]
+    hyperedges = hyperedges_from_data(data)
 
     ratio = (args.train_prop, args.valid_prop, 1 - args.train_prop - args.valid_prop)
 
@@ -98,9 +104,10 @@ def generate_ind_split_hyperedges(data, args, seed):
 
     print(f'train_size: {train_size}, valid_size: {valid_size}, test_size: {test_size}')
 
-    train_mns, train_sns, train_cns = neg_generator(GP_train, train_size)
-    valid_mns, valid_sns, valid_cns = neg_generator(GP_valid, valid_size)
-    test_mns, test_sns, test_cns = neg_generator(GP_test, test_size)
+    all_positive_hyperedges = set(hyperedges)
+    train_mns, train_sns, train_cns = neg_generator_excluding(GP_train, train_size, all_positive_hyperedges)
+    valid_mns, valid_sns, valid_cns = neg_generator_excluding(GP_valid, valid_size, all_positive_hyperedges)
+    test_mns, test_sns, test_cns = neg_generator_excluding(GP_test, test_size, all_positive_hyperedges)
 
     # positive samples
     ground_train_data = []
@@ -116,6 +123,12 @@ def generate_ind_split_hyperedges(data, args, seed):
     f'./lib_edge_splits/{args.edge_split_mode}/{args.dname}/split_{seed}.pt')
 
 def generate_observed_ind_split_hyperedges(data, args, seed):
+    raise ValueError(
+        "The observed edge prediction protocol currently supports only "
+        "--edge_split_mode=trand. The observed ind split is disabled because "
+        "its support graph contains the train positives."
+    )
+
     HE = hyperedges_from_data(data)
 
     ratio = (args.train_prop, args.valid_prop, 1 - args.train_prop - args.valid_prop)
@@ -176,14 +189,7 @@ def generate_observed_ind_split_hyperedges(data, args, seed):
 
 def generate_split_hyperedges(data,args,seed):
 
-    hyperedge_index = data.hyperedge_index.to('cpu')
-
-    hyperedges = defaultdict(set)
-
-    for node, edge in zip(*hyperedge_index.tolist()):
-        hyperedges[edge].add(node)
-
-    HE = [frozenset(nodes) for nodes in hyperedges.values()]
+    HE = hyperedges_from_data(data)
     
     base_cover = get_cover_idx(HE)
     union = get_union(HE)
@@ -234,9 +240,10 @@ def generate_split_hyperedges(data,args,seed):
     GP_valid = ground_valid_data + ground_train_data + train_only_data + valid_only_data
     GP_test = GP_valid
     
-    train_mns, train_sns, train_cns = neg_generator(GP_train, ground_train_num+train_only_num)
-    valid_mns, valid_sns, valid_cns = neg_generator(GP_valid, ground_valid_num+valid_only_num)
-    test_mns, test_sns, test_cns = neg_generator(GP_test, test_num)
+    all_positive_hyperedges = set(HE)
+    train_mns, train_sns, train_cns = neg_generator_excluding(GP_train, ground_train_num+train_only_num, all_positive_hyperedges)
+    valid_mns, valid_sns, valid_cns = neg_generator_excluding(GP_valid, ground_valid_num+valid_only_num, all_positive_hyperedges)
+    test_mns, test_sns, test_cns = neg_generator_excluding(GP_test, test_num, all_positive_hyperedges)
     
     # positive samples
     ground_train_data = [list(edge) for edge in ground_train_data]

--- a/dhgbench/lib_dataset/edge_sampler.py
+++ b/dhgbench/lib_dataset/edge_sampler.py
@@ -24,10 +24,30 @@ def neg_generator(HE, pred_num):
     
     return t_mns, t_sns, t_cns
 
+def neg_generator_excluding(HE, pred_num, exclude_hyperedges):
+    mns = MNSSampler(pred_num)
+    sns = SNSSampler(pred_num)
+    cns = CNSSampler(pred_num)
+
+    context_hyperedges = set(HE)
+    exclude_hyperedges = set(exclude_hyperedges)
+
+    t_mns = mns(context_hyperedges, exclude_hyperedges=exclude_hyperedges)
+    t_sns = sns(context_hyperedges, exclude_hyperedges=exclude_hyperedges)
+    t_cns = cns(context_hyperedges, exclude_hyperedges=exclude_hyperedges)
+
+    t_mns = [list(edge) for edge in list(t_mns)]
+    t_sns = [list(edge) for edge in list(t_sns)]
+    t_cns = [list(edge) for edge in list(t_cns)]
+
+    return t_mns, t_sns, t_cns
+
 def negative_sample(
-        nodes_to_neighbors, size_dist, num_negative, hyperedges, method, corrupt_num = 1, half=False, rw_path = None):
+        nodes_to_neighbors, size_dist, num_negative, hyperedges, method, corrupt_num = 1, half=False, rw_path = None,
+        exclude_hyperedges = None):
     nodes = list(nodes_to_neighbors.keys())
     neg_samples = []
+    forbidden_hyperedges = set(hyperedges if exclude_hyperedges is None else exclude_hyperedges)
     if method == 'UNS':
         size_dist = get_pure_sample_size_dist(len(nodes))
     
@@ -35,12 +55,14 @@ def negative_sample(
     if method in ['SNS', 'UNS']:
         for i in tqdm(range(num_negative), leave=False):
             sampled_edge = sized_random_sampling(
-                size_dist, nodes, nodes_to_neighbors, hyperedges)
+                size_dist, nodes, nodes_to_neighbors, forbidden_hyperedges)
             neg_samples.append(sampled_edge)
     elif method == 'MNS':
         for i in tqdm(range(num_negative), leave=False):
             sampled_node = sized_mf_sampling(
-                size_dist, nodes, nodes_to_neighbors, hyperedges)
+                size_dist, nodes, nodes_to_neighbors,
+                forbidden_hyperedges if exclude_hyperedges is not None else hyperedges,
+                check_existing=exclude_hyperedges is not None)
             neg_samples.append(sampled_node)     
     elif method == 'CNS':
         list_hyperedges = list(hyperedges)
@@ -48,13 +70,13 @@ def negative_sample(
         for i in tqdm(range(num_negative), leave=False):
             sampled_edge = clique_negative_sampling(
                 hyperedges, nodes_to_neighbors, num_negative, list_hyperedges,
-                node_set)
+                node_set, forbidden_hyperedges=forbidden_hyperedges)
             neg_samples.append(sampled_edge)       
 
     return neg_samples
 
 def generate_negative_samples_for_hyperedges(
-        hyperedges, method, neg_samples_size, corrupt_num = 1, half=False, rw_path = None):
+        hyperedges, method, neg_samples_size, corrupt_num = 1, half=False, rw_path = None, exclude_hyperedges = None):
     #print(hyperedges)
     edges = {
         frozenset({u, v}) for hedge in hyperedges
@@ -70,7 +92,8 @@ def generate_negative_samples_for_hyperedges(
     #print('Generating Negative Samples')
     total = math.ceil(neg_samples_size)
     neg_samples = negative_sample(
-        nodes_to_neighbors, size_dist, total, hyperedges, method, corrupt_num = 1, half=False, rw_path = rw_path)
+        nodes_to_neighbors, size_dist, total, hyperedges, method, corrupt_num = 1, half=False, rw_path = rw_path,
+        exclude_hyperedges = exclude_hyperedges)
     negative_hyperedges = [frozenset(x) for x, y in neg_samples]
     
     return negative_hyperedges
@@ -78,25 +101,28 @@ def generate_negative_samples_for_hyperedges(
 class SNSSampler(object):
     def __init__(self, pred_num):
         self.pred_num = pred_num
-    def __call__(self, hedges):
+    def __call__(self, hedges, exclude_hyperedges=None):
         neg_samples_size = int(self.pred_num)
-        neg_samples = generate_negative_samples_for_hyperedges(hedges, 'SNS', neg_samples_size)
+        neg_samples = generate_negative_samples_for_hyperedges(
+            hedges, 'SNS', neg_samples_size, exclude_hyperedges=exclude_hyperedges)
         return neg_samples
 
 class MNSSampler(object):
     def __init__(self, pred_num):
         self.pred_num = pred_num
-    def __call__(self, hedges):
+    def __call__(self, hedges, exclude_hyperedges=None):
         neg_samples_size = int(self.pred_num)
-        neg_samples = generate_negative_samples_for_hyperedges(hedges, 'MNS', neg_samples_size)
+        neg_samples = generate_negative_samples_for_hyperedges(
+            hedges, 'MNS', neg_samples_size, exclude_hyperedges=exclude_hyperedges)
         return neg_samples
     
 class CNSSampler(object):
     def __init__(self, pred_num):
         self.pred_num = pred_num
-    def __call__(self, hedges):
+    def __call__(self, hedges, exclude_hyperedges=None):
         neg_samples_size = int(self.pred_num)
-        neg_samples = generate_negative_samples_for_hyperedges(hedges, 'CNS', neg_samples_size)
+        neg_samples = generate_negative_samples_for_hyperedges(
+            hedges, 'CNS', neg_samples_size, exclude_hyperedges=exclude_hyperedges)
         return neg_samples
 
 '''-------------SNS Sampling Utils------------------'''
@@ -197,7 +223,7 @@ def mfinder_sampling(nodes_to_neighbors, k):
 
     return sampled_nodes, induced_edges
 
-def sized_mf_sampling(size_dist, nodes, nodes_to_neighbors, hyperedges):
+def sized_mf_sampling(size_dist, nodes, nodes_to_neighbors, hyperedges, check_existing=False):
     vals = [v for v, p in size_dist]
     p = [p for v, p in size_dist]
     sampled_size = np.random.choice(vals, p=p)
@@ -207,6 +233,8 @@ def sized_mf_sampling(size_dist, nodes, nodes_to_neighbors, hyperedges):
         sampled_nodes, sampled_edge = mfinder_sampling(
             nodes_to_neighbors, sampled_size)'''
     sampled_nodes= mfinder_sampling(nodes_to_neighbors, sampled_size)
+    while check_existing and frozenset(sampled_nodes[0]) in hyperedges:
+        sampled_nodes= mfinder_sampling(nodes_to_neighbors, sampled_size)
     hyperedges.remove(frozenset({'a', 'b'}))
     return sampled_nodes
 
@@ -214,11 +242,13 @@ def sized_mf_sampling(size_dist, nodes, nodes_to_neighbors, hyperedges):
 
 def clique_negative_sampling(
         hyperedges, nodes_to_neighbors, num_negative,
-        list_hyperedges, node_set):
+        list_hyperedges, node_set, forbidden_hyperedges = None):
+    if forbidden_hyperedges is None:
+        forbidden_hyperedges = hyperedges
     edgeidx = np.random.choice(len(hyperedges), size=1)[0]
     neg = list_hyperedges[edgeidx]
 
-    while neg in hyperedges:
+    while neg in forbidden_hyperedges:
         edgeidx = np.random.choice(len(hyperedges), size=1)[0]
         edge = list(list_hyperedges[edgeidx])
         node_to_remove = np.random.choice(len(edge), size=1)[0]

--- a/dhgbench/lib_utils/aggregator.py
+++ b/dhgbench/lib_utils/aggregator.py
@@ -1,6 +1,5 @@
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
 from collections import defaultdict
 from lib_models.HNN import MLP
 from torch_geometric.nn import global_max_pool,global_mean_pool
@@ -189,7 +188,7 @@ class MaxminAggregator(nn.Module):
         return max_val - min_val
     
     def classify(self, embedding):
-        return F.sigmoid(self.classifier(embedding))
+        return self.classifier(embedding)
     
     def forward(self, embeddings,method):
         embedding = self.aggregate(embeddings,method)
@@ -223,7 +222,7 @@ class MaxAggregator(nn.Module):
         return max_val
     
     def classify(self, embedding):
-        return F.sigmoid(self.classifier(embedding))
+        return self.classifier(embedding)
     
     def forward(self, embeddings,method):
         embedding = self.aggregate(embeddings,method)

--- a/dhgbench/lib_utils/exp_agent.py
+++ b/dhgbench/lib_utils/exp_agent.py
@@ -32,6 +32,12 @@ class ExpAgent:
         self.train_times = []
 
     def edge_pred_train_eval(self,data):
+        if self.args.edge_pred_protocol == 'observed' and self.args.edge_split_mode == 'ind':
+            raise ValueError(
+                "The observed edge prediction protocol currently supports only "
+                "--edge_split_mode=trand. The observed ind split is disabled because "
+                "its support graph contains the train positives."
+            )
         
         metrics_dict = {'train':defaultdict(list),'val':defaultdict(list),'test':defaultdict(list)}
         

--- a/dhgbench/lib_utils/exp_agent.py
+++ b/dhgbench/lib_utils/exp_agent.py
@@ -11,8 +11,11 @@ from lib_models.HNN import HCHA,HyperGCN,HNHN,SetGNN,UniGNN,UniGCNII,LEGCN,Hyper
                             PlainUnigencoder,HJRL,SheafHyperGNN,EHNN,TMPHN,PhenomNN,PhenomNNS,DPHGNN,TFHNN,PlainMLP,HyperGT,CEGCN,CEGAT
 
 from lib_dataset.data_perturbation import perturbation
-from lib_dataset.edge_loaders import generate_edge_loaders,generate_split_hyperedges,generate_ind_split_hyperedges
+from lib_dataset.edge_loaders import generate_edge_loaders,generate_split_hyperedges,generate_ind_split_hyperedges,\
+                                    generate_observed_split_hyperedges,generate_observed_ind_split_hyperedges,\
+                                    build_observed_support_data
 from lib_dataset.hg_loaders import generate_split_hypergraphs,generate_hg_loaders
+from lib_models.HNN.preprocessing import algo_preprocessing
 from lib_utils.aggregator import EdgePredictor,MeanAggregator,MaxminAggregator,MaxAggregator,HyperGPredictor
 from lib_utils.metrics import aggr_metrics,avg_result_printer_edge
 
@@ -36,31 +39,45 @@ class ExpAgent:
             
             fix_seed(seed) 
             
-            dir_path = f"{self.args.edge_save_dir}{self.args.edge_split_mode}/{self.args.dname}/"
+            if self.args.edge_pred_protocol == 'observed':
+                dir_path = f"{self.args.edge_save_dir}{self.args.edge_split_mode}_{self.args.edge_pred_protocol}/{self.args.dname}/"
+            else:
+                dir_path = f"{self.args.edge_save_dir}{self.args.edge_split_mode}/{self.args.dname}/"
             
             if self.args.edge_split_mode == 'ind':
 
                 file_path = dir_path+f"split_{seed}.pt"
                 if not os.path.exists(file_path):
                     os.makedirs(dir_path, exist_ok=True)
-                    generate_ind_split_hyperedges(data,self.args,seed)
+                    if self.args.edge_pred_protocol == 'observed':
+                        generate_observed_ind_split_hyperedges(data,self.args,seed)
+                    else:
+                        generate_ind_split_hyperedges(data,self.args,seed)
 
             elif self.args.edge_split_mode == 'trand':
                 
                 file_path = dir_path+f"split_{seed}.pt"
                 if not os.path.exists(file_path):
                     os.makedirs(dir_path, exist_ok=True)
-                    generate_split_hyperedges(data,self.args,seed)
+                    if self.args.edge_pred_protocol == 'observed':
+                        generate_observed_split_hyperedges(data,self.args,seed)
+                    else:
+                        generate_split_hyperedges(data,self.args,seed)
 
             else:
 
                 raise NotImplementedError
                 
             data_dict = torch.load(file_path, weights_only=False)
+            if self.args.edge_pred_protocol == 'observed':
+                data_for_edge_pred = build_observed_support_data(data,data_dict,self.args)
+                data_for_edge_pred = algo_preprocessing(data_for_edge_pred,self.args)
+            else:
+                data_for_edge_pred = data
             batch_loaders = generate_edge_loaders(data_dict,self.args)
             
             self.args.embedding_mode = True 
-            encoder = parse_model(self.args,data) 
+            encoder = parse_model(self.args,data_for_edge_pred)
             
             if self.args.aggr_mode=='maxmin':
                 aggregator = MaxminAggregator(self.args) 
@@ -75,15 +92,15 @@ class ExpAgent:
             else:
                 model = model.to(self.args.device)
             
-            model = self.trainer.training(model,data,self.args,seed_split=batch_loaders,task_type='edge_pred')
+            model = self.trainer.training(model,data_for_edge_pred,self.args,seed_split=batch_loaders,task_type='edge_pred')
 
             if self.args.eval_verbose:
                 print(f'------------------------------[Seed {seed}]-----------------------------------')
-                result=self.evaluator.evaluate(model,data,seed_split=batch_loaders,task_type='edge_pred',verbose=True)
+                result=self.evaluator.evaluate(model,data_for_edge_pred,seed_split=batch_loaders,task_type='edge_pred',verbose=True)
                 metrics_dict = aggr_metrics(metrics_dict,result) 
                 print(f'------------------------------------------------------------------------------')
             else:
-                result=self.evaluator.evaluate(model,data,seed_split=batch_loaders,task_type='edge_pred',verbose=True)
+                result=self.evaluator.evaluate(model,data_for_edge_pred,seed_split=batch_loaders,task_type='edge_pred',verbose=True)
                 metrics_dict = aggr_metrics(metrics_dict,result) 
 
         print(f'---------------------------------[Final]--------------------------------------')

--- a/dhgbench/lib_utils/metrics.py
+++ b/dhgbench/lib_utils/metrics.py
@@ -178,7 +178,7 @@ def evaluate_edge_loader(model, data, dataloader):
             if is_last:
                 break
 
-        test_preds = torch.sigmoid(torch.stack(test_preds).squeeze())
+        test_preds = torch.sigmoid(torch.stack(test_preds).view(-1))
         test_labels = torch.cat(test_labels, dim=0)
 
     return test_preds.tolist(), test_labels.tolist()

--- a/dhgbench/lib_utils/train_agent.py
+++ b/dhgbench/lib_utils/train_agent.py
@@ -129,7 +129,6 @@ class Trainer:
 
                 pos_preds = model.aggregate(n, pos_hedges, mode='Train') 
                 neg_preds = model.aggregate(n, neg_hedges, mode='Train') 
-                pos_preds,neg_preds = torch.sigmoid(pos_preds),torch.sigmoid(neg_preds)
                 
                 d_real_loss = F.binary_cross_entropy_with_logits(pos_preds, pos_labels) 
                 d_fake_loss = F.binary_cross_entropy_with_logits(neg_preds, neg_labels) 
@@ -143,7 +142,8 @@ class Trainer:
                 if is_last :
                     break 
             
-            if (epoch+1) % args.display_step == 0:
+            should_evaluate = (epoch+1) % args.display_step == 0 or (epoch+1) == args.epochs
+            if should_evaluate:
                 
                 print(f'Epoch: {epoch+1:02d}, Training loss: {total_loss:.4f}')
                 
@@ -160,6 +160,8 @@ class Trainer:
         print(f'Training Time: {end_time-start_time:.2f}')
 
         if args.early_stop:
+            if best_model is None:
+                best_model = copy.deepcopy(model)
             return best_model
         else:
             return model

--- a/dhgbench/parameter_parser.py
+++ b/dhgbench/parameter_parser.py
@@ -132,6 +132,7 @@ def parameter_parser():
     parser.add_argument('--exclude_self', action='store_true')
     
     parser.add_argument('--edge_split_mode',default='ind',choices=['ind','trand'])
+    parser.add_argument('--edge_pred_protocol',default='legacy',choices=['legacy','observed'])
     parser.add_argument('--edge_save_dir', action='store_true',default=f'./lib_edge_splits/') 
     parser.add_argument('--edge_batch_size', action='store_true',default=512) 
     parser.add_argument('--e_embed_hidden',default=64) 

--- a/tests/test_edge_pred_logits.py
+++ b/tests/test_edge_pred_logits.py
@@ -1,0 +1,101 @@
+import sys
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+import torch
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "dhgbench"))
+
+from lib_utils.aggregator import MaxAggregator, MaxminAggregator  # noqa: E402
+from lib_dataset.edge_loaders import HEBatchGenerator  # noqa: E402
+from lib_utils import train_agent  # noqa: E402
+from lib_utils.train_agent import Trainer  # noqa: E402
+
+
+class FixedClassifier(torch.nn.Module):
+    def forward(self, embedding):
+        return torch.tensor([[-2.0], [0.0], [2.0]], dtype=embedding.dtype, device=embedding.device)
+
+
+class TrainableEdgeModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.tensor(0.0))
+
+    def reset_parameters(self):
+        with torch.no_grad():
+            self.weight.zero_()
+
+    def encoding(self, data):
+        return torch.zeros(3, 4), None
+
+    def aggregate(self, nfeat, hedges, mode="Train"):
+        return self.weight.expand(len(hedges))
+
+
+class EdgePredictionLogitContractTest(unittest.TestCase):
+    def test_max_aggregators_return_raw_logits(self):
+        for aggregator_cls in [MaxAggregator, MaxminAggregator]:
+            with self.subTest(aggregator=aggregator_cls.__name__):
+                aggregator = aggregator_cls.__new__(aggregator_cls)
+                torch.nn.Module.__init__(aggregator)
+                aggregator.classifier = FixedClassifier()
+
+                logits = aggregator.classify(torch.zeros(3, 4))
+
+                expected = torch.tensor([[-2.0], [0.0], [2.0]])
+                self.assertTrue(torch.equal(logits.cpu(), expected))
+                self.assertLess(float(logits.min()), 0.0)
+                self.assertGreater(float(logits.max()), 1.0)
+
+    def test_edge_training_uses_logits_for_bce_loss(self):
+        source = (ROOT / "dhgbench" / "lib_utils" / "train_agent.py").read_text()
+
+        self.assertIn("F.binary_cross_entropy_with_logits(pos_preds, pos_labels)", source)
+        self.assertIn("F.binary_cross_entropy_with_logits(neg_preds, neg_labels)", source)
+        self.assertNotIn("torch.sigmoid(pos_preds)", source)
+        self.assertNotIn("torch.sigmoid(neg_preds)", source)
+
+    def test_edge_early_stop_evaluates_final_epoch_before_return(self):
+        def edge_metrics(prefix):
+            if prefix == "train":
+                return {"roc_train": 0.5, "ap_train": 0.5}
+            metrics = {}
+            for name in ["sns", "mns", "cns", "mixed", "average"]:
+                metrics[f"roc_{name}"] = 0.5
+                metrics[f"ap_{name}"] = 0.5
+            return metrics
+
+        args = SimpleNamespace(
+            device="cpu",
+            lr=0.01,
+            wd=0.0,
+            epochs=1,
+            display_step=20,
+            early_stop=True,
+        )
+        batch_loaders = {
+            "train_pos": HEBatchGenerator([[0, 1]], [1], batch_size=1, device="cpu"),
+            "train_neg": HEBatchGenerator([[1, 2]], [0], batch_size=1, device="cpu"),
+        }
+        original_evaluate_edge = train_agent.evaluate_edge
+        train_agent.evaluate_edge = lambda model, data, loaders: (
+            edge_metrics("train"),
+            edge_metrics("val"),
+            edge_metrics("test"),
+        )
+        try:
+            model = Trainer(args).semi_edge_pred_training(
+                TrainableEdgeModel(), object(), batch_loaders, args
+            )
+        finally:
+            train_agent.evaluate_edge = original_evaluate_edge
+
+        self.assertIsInstance(model, TrainableEdgeModel)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_edge_pred_observed_protocol.py
+++ b/tests/test_edge_pred_observed_protocol.py
@@ -1,0 +1,106 @@
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+import torch
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "dhgbench"))
+
+from lib_dataset.edge_loaders import (  # noqa: E402
+    build_observed_support_data,
+    generate_observed_split_hyperedges,
+    load_val,
+)
+
+
+def make_hyperedge_index(hyperedges):
+    rows = []
+    cols = []
+    for edge_id, nodes in enumerate(hyperedges):
+        for node in nodes:
+            rows.append(node)
+            cols.append(edge_id)
+    return torch.tensor([rows, cols], dtype=torch.long)
+
+
+class ObservedEdgePredictionProtocolTest(unittest.TestCase):
+    def test_observed_protocol_separates_support_targets_and_negatives(self):
+        hyperedges = [
+            [0, 1, 2],
+            [2, 3, 4],
+            [4, 5, 6],
+            [0, 6, 7],
+            [1, 3, 5],
+            [2, 5, 7],
+            [0, 3, 6],
+            [1, 4, 7],
+            [0, 2, 5],
+            [3, 6, 7],
+            [1, 5, 6],
+            [2, 4, 7],
+        ]
+        data = SimpleNamespace(hyperedge_index=make_hyperedge_index(hyperedges))
+        with tempfile.TemporaryDirectory() as tmpdir:
+            args = SimpleNamespace(
+                train_prop=0.6,
+                valid_prop=0.2,
+                edge_save_dir=f"{tmpdir}/",
+                edge_split_mode="trand",
+                edge_pred_protocol="observed",
+                dname="toy",
+                device="cpu",
+            )
+            generate_observed_split_hyperedges(data, args, seed=0)
+            split_path = Path(tmpdir) / "trand_observed" / "toy" / "split_0.pt"
+            data_dict = torch.load(split_path, weights_only=False)
+
+        support = {frozenset(edge) for edge in data_dict["support_pos"]}
+        train_pos = {frozenset(edge) for edge in data_dict["train_only_pos"]}
+        valid_pos = {frozenset(edge) for edge in data_dict["ground_valid"] + data_dict["valid_only_pos"]}
+        test_pos = {frozenset(edge) for edge in data_dict["test_pos"]}
+        all_positive = {frozenset(edge) for edge in hyperedges}
+
+        self.assertEqual(data_dict["edge_pred_protocol"], "observed")
+        self.assertTrue(support)
+        self.assertTrue(train_pos)
+        self.assertTrue(valid_pos)
+        self.assertTrue(test_pos)
+        self.assertTrue(support.isdisjoint(valid_pos))
+        self.assertTrue(support.isdisjoint(test_pos))
+
+        val_loader = load_val(data_dict, bs=128, device="cpu", label="pos")
+        self.assertEqual({frozenset(edge) for edge in val_loader.hyperedges}, valid_pos)
+
+        for key in [
+            "train_mns",
+            "train_sns",
+            "train_cns",
+            "valid_mns",
+            "valid_sns",
+            "valid_cns",
+            "test_mns",
+            "test_sns",
+            "test_cns",
+        ]:
+            self.assertTrue({frozenset(edge) for edge in data_dict[key]}.isdisjoint(all_positive), key)
+
+    def test_support_data_uses_only_observed_hyperedges(self):
+        data = SimpleNamespace(
+            hyperedge_index=make_hyperedge_index([[0, 1, 2], [2, 3, 4], [4, 5, 6]]),
+            data=SimpleNamespace(),
+        )
+        data_dict = {"support_pos": [[0, 1, 2], [2, 3, 4]]}
+        args = SimpleNamespace(device="cpu")
+
+        support_data = build_observed_support_data(data, data_dict, args)
+
+        self.assertEqual(support_data.num_hyperedges, 2)
+        self.assertEqual(set(support_data.hyperedge_index[1].tolist()), {0, 1})
+        self.assertEqual(support_data.hyperedge_index.shape[1], 6)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_edge_pred_observed_protocol.py
+++ b/tests/test_edge_pred_observed_protocol.py
@@ -10,10 +10,14 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "dhgbench"))
 
 from lib_dataset.edge_loaders import (  # noqa: E402
+    HEBatchGenerator,
     build_observed_support_data,
+    deduplicate_hyperedges,
+    generate_observed_ind_split_hyperedges,
     generate_observed_split_hyperedges,
     load_val,
 )
+from lib_utils.metrics import evaluate_edge_loader  # noqa: E402
 
 
 def make_hyperedge_index(hyperedges):
@@ -27,6 +31,19 @@ def make_hyperedge_index(hyperedges):
 
 
 class ObservedEdgePredictionProtocolTest(unittest.TestCase):
+    def test_deduplicate_hyperedges_uses_node_set_identity(self):
+        hyperedges = [
+            [0, 1, 2],
+            [2, 1, 0],
+            [3, 4, 5],
+            [3, 4, 5],
+            [5, 6, 7],
+        ]
+
+        unique = deduplicate_hyperedges(hyperedges)
+
+        self.assertEqual(unique, [frozenset([0, 1, 2]), frozenset([3, 4, 5]), frozenset([5, 6, 7])])
+
     def test_observed_protocol_separates_support_targets_and_negatives(self):
         hyperedges = [
             [0, 1, 2],
@@ -41,6 +58,8 @@ class ObservedEdgePredictionProtocolTest(unittest.TestCase):
             [3, 6, 7],
             [1, 5, 6],
             [2, 4, 7],
+            [2, 1, 0],
+            [7, 4, 2],
         ]
         data = SimpleNamespace(hyperedge_index=make_hyperedge_index(hyperedges))
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -68,8 +87,13 @@ class ObservedEdgePredictionProtocolTest(unittest.TestCase):
         self.assertTrue(train_pos)
         self.assertTrue(valid_pos)
         self.assertTrue(test_pos)
+        self.assertTrue(support.isdisjoint(train_pos))
         self.assertTrue(support.isdisjoint(valid_pos))
         self.assertTrue(support.isdisjoint(test_pos))
+        self.assertTrue(train_pos.isdisjoint(valid_pos))
+        self.assertTrue(train_pos.isdisjoint(test_pos))
+        self.assertTrue(valid_pos.isdisjoint(test_pos))
+        self.assertEqual(len(support | train_pos | valid_pos | test_pos), len(all_positive))
 
         val_loader = load_val(data_dict, bs=128, device="cpu", label="pos")
         self.assertEqual({frozenset(edge) for edge in val_loader.hyperedges}, valid_pos)
@@ -100,6 +124,41 @@ class ObservedEdgePredictionProtocolTest(unittest.TestCase):
         self.assertEqual(support_data.num_hyperedges, 2)
         self.assertEqual(set(support_data.hyperedge_index[1].tolist()), {0, 1})
         self.assertEqual(support_data.hyperedge_index.shape[1], 6)
+
+    def test_observed_ind_split_is_disabled(self):
+        data = SimpleNamespace(
+            hyperedge_index=make_hyperedge_index([[0, 1, 2], [2, 3, 4], [4, 5, 6]])
+        )
+        args = SimpleNamespace(
+            train_prop=0.6,
+            valid_prop=0.2,
+            edge_save_dir="/tmp/",
+            edge_split_mode="ind",
+            edge_pred_protocol="observed",
+            dname="toy",
+            device="cpu",
+        )
+
+        with self.assertRaisesRegex(ValueError, "observed edge prediction protocol"):
+            generate_observed_ind_split_hyperedges(data, args, seed=0)
+
+    def test_singleton_edge_eval_returns_lists(self):
+        class SingletonEvalModel:
+            def eval(self):
+                pass
+
+            def encoding(self, data):
+                return torch.zeros(2, 4), None
+
+            def aggregate(self, nfeat, hedges, mode="Eval"):
+                return [torch.tensor(0.0) for _ in hedges]
+
+        loader = HEBatchGenerator([[0, 1]], [1], batch_size=128, device="cpu", test_generator=True)
+
+        preds, labels = evaluate_edge_loader(SingletonEvalModel(), object(), loader)
+
+        self.assertEqual(preds, [0.5])
+        self.assertEqual(labels, [1.0])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

This PR adds an opt-in corrected protocol for `edge_pred` via `--edge_pred_protocol=observed`, while preserving the current DHG-Bench behavior as the default `legacy` protocol.

The observed protocol makes held-out hyperedge prediction cleaner by:

- Building node embeddings from an observed/support hypergraph only, instead of encoding the full original hypergraph.
- Using validation positives from the validation target set rather than reusing training positives.
- Sampling negatives while excluding the full set of true hyperedges, so held-out positives are not accidentally sampled as negatives.
- Recomputing model-specific preprocessing after constructing the support-only graph.

## Motivation

In the current `edge_pred` pipeline, train/validation/test positive hyperedges are split for scoring, but `model.encoding(data)` still receives `data.hyperedge_index` from the full original hypergraph. This means held-out hyperedges can participate in message passing before they are scored.

The current validation positive loader also uses `train_only_pos + ground_train` for `label="pos"`, so validation metrics do not evaluate the intended validation positives. In addition, test negative sampling can miss held-out test positives in its exclusion set.

## Compatibility

The default remains:

```bash
--edge_pred_protocol=legacy
```

Users can opt into the corrected protocol with:

```bash
python main.py --dname=pubmed --task_type=edge_pred --method=EDHNN --is_default=True --edge_pred_protocol=observed
```

Observed split files are written under a separate split-cache directory such as `lib_edge_splits/ind_observed/...`, so existing legacy split caches are not overwritten.

## Validation

Passed:

```bash
python -m unittest discover -s tests -v
python -m py_compile dhgbench/parameter_parser.py dhgbench/lib_dataset/edge_sampler.py dhgbench/lib_dataset/edge_loaders.py dhgbench/lib_utils/exp_agent.py tests/test_edge_pred_observed_protocol.py
git diff --check
```

One-epoch smoke tests on `pubmed + EDHNN` also completed successfully:

- `--edge_pred_protocol=observed`: exit code 0; test AVG AUROC/AP = 0.9923 / 0.9848
- `--edge_pred_protocol=legacy`: exit code 0; test AVG AUROC/AP = 0.6228 / 0.6294
