### PR TITLE
Fix paper-compatible HCHA, HyperGT, and DPHGNN implementation paths

### DIFF
--- a/dhgbench/lib_models/HNN/dphgnn.py
+++ b/dhgbench/lib_models/HNN/dphgnn.py
@@ -17,7 +17,10 @@ class DPHGNN(nn.Module):
         self.spectral_layer = HGSpectralNet(num_features,args.spectral_embed_dim)
         self.fc = nn.Linear(in_features=self.spectral_layer.out_channels+self.taa_layer.out_channels, 
                             out_features=self.fc_dim).to(args.device)
-        self.dff_layer = DFF(self.fc_dim,num_targets,args)
+        if getattr(args, 'DPHGNN_dff_mode', 'attention') == 'paper':
+            self.dff_layer = PaperDFF(self.fc_dim,num_targets,args)
+        else:
+            self.dff_layer = DFF(self.fc_dim,num_targets,args)
     
     def reset_parameters(self):
         self.taa_layer.reset_parameters()
@@ -114,6 +117,96 @@ class HypergraphConv(nn.Module):
             X = F.dropout(X, self.dropout, training=self.training)
             
         return X
+
+class PaperDFF(nn.Module):
+    def __init__(self, in_channels: int, out_channels: int, args):
+        super(PaperDFF, self).__init__()
+        self.dff_MLP_hidden = args.dff_MLP_hidden
+        self.dff_num_layers = args.dff_num_layers
+
+        self.convs = nn.ModuleList()
+        self.convs.append(PaperDPHGNNConv(in_channels, self.dff_MLP_hidden, args, is_last=False))
+        for _ in range(self.dff_num_layers - 1):
+            self.convs.append(PaperDPHGNNConv(self.dff_MLP_hidden, self.dff_MLP_hidden, args, is_last=False))
+        self.convs.append(PaperHypergraphConv(self.dff_MLP_hidden, out_channels))
+
+    def reset_parameters(self):
+        for conv in self.convs:
+            conv.reset_parameters()
+
+    def forward(self, X, HG, S_features):
+        for conv in self.convs[:-1]:
+            X = conv(X, HG, S_features)
+        return self.convs[-1](X, HG, S_features)
+
+class PaperDPHGNNConv(nn.Module):
+    def __init__(
+        self,
+        in_channels,
+        out_channels,
+        args,
+        bias: bool = True,
+        drop_rate: float = 0.5,
+        is_last: bool = False,
+    ):
+        super(PaperDPHGNNConv, self).__init__()
+        self.is_last = is_last
+        self.dropout = drop_rate
+        self.star_proj = nn.Linear(args.expan_dim, in_channels, bias=bias)
+        self.msg_proj = nn.Linear(in_channels, out_channels, bias=bias)
+        self.skip_proj = nn.Linear(in_channels, out_channels, bias=bias)
+
+    def reset_parameters(self):
+        self.star_proj.reset_parameters()
+        self.msg_proj.reset_parameters()
+        self.skip_proj.reset_parameters()
+
+    def forward(self, X, hyperedge_index, S_features):
+        V, E = hyperedge_index
+        num_nodes = X.size(0)
+        num_edges = S_features.size(0)
+
+        ones = torch.ones(V.shape[0], device=V.device, dtype=X.dtype)
+        D_v = torch_scatter.scatter_add(ones, V, dim=0, dim_size=num_nodes).clamp_min(1)
+        D_e = torch_scatter.scatter_add(ones, E, dim=0, dim_size=num_edges).clamp_min(1)
+        Dv_inv_sqrt = D_v.pow(-0.5)
+        De_inv = D_e.pow(-1.0)
+
+        node_to_edge = scatter_add(X[V] * Dv_inv_sqrt[V].unsqueeze(-1), E, dim=0, dim_size=num_edges)
+        star_term = self.star_proj(S_features) * De_inv.unsqueeze(-1)
+        fused_edge = node_to_edge + star_term
+
+        edge_to_node = scatter_add(fused_edge[E] * De_inv[E].unsqueeze(-1), V, dim=0, dim_size=num_nodes)
+        X = self.skip_proj(X) + self.msg_proj(edge_to_node)
+
+        if not self.is_last:
+            X = F.elu(X)
+            X = F.dropout(X, self.dropout, training=self.training)
+
+        return X
+
+class PaperHypergraphConv(nn.Module):
+    def __init__(self, in_channels, out_channels, bias: bool = True):
+        super(PaperHypergraphConv, self).__init__()
+        self.W = nn.Linear(in_channels, out_channels, bias=bias)
+
+    def reset_parameters(self):
+        self.W.reset_parameters()
+
+    def forward(self, X, hyperedge_index, S_features):
+        V, E = hyperedge_index
+        num_nodes = X.size(0)
+        num_edges = int(E.max().item()) + 1
+
+        ones = torch.ones(V.shape[0], device=V.device, dtype=X.dtype)
+        D_v = torch_scatter.scatter_add(ones, V, dim=0, dim_size=num_nodes).clamp_min(1)
+        D_e = torch_scatter.scatter_add(ones, E, dim=0, dim_size=num_edges).clamp_min(1)
+        Dv_inv_sqrt = D_v.pow(-0.5)
+        De_inv = D_e.pow(-1.0)
+
+        node_to_edge = scatter_add(X[V] * Dv_inv_sqrt[V].unsqueeze(-1), E, dim=0, dim_size=num_edges)
+        edge_to_node = scatter_add(node_to_edge[E] * De_inv[E].unsqueeze(-1), V, dim=0, dim_size=num_nodes)
+        return self.W(edge_to_node)
 
 class DPHGNNConv(nn.Module):
     def __init__(self,

--- a/dhgbench/lib_models/HNN/hgnn.py
+++ b/dhgbench/lib_models/HNN/hgnn.py
@@ -12,6 +12,7 @@ class HypergraphConv(MessagePassing):
 
     def __init__(self, in_channels, out_channels, symdegnorm=False, use_attention=False, heads=1,
                  concat=True, negative_slope=0.2, dropout=0, bias=True,
+                 attention_mode='edge',
                  **kwargs):
         kwargs.setdefault('aggr', 'add')
         super(HypergraphConv, self).__init__(node_dim=0, **kwargs)
@@ -20,6 +21,9 @@ class HypergraphConv(MessagePassing):
         self.out_channels = out_channels
         self.use_attention = use_attention
         self.symdegnorm = symdegnorm
+        self.attention_mode = attention_mode
+        if self.use_attention and self.attention_mode not in ['node', 'edge']:
+            raise ValueError("attention_mode must be either 'node' or 'edge'")
 
         if self.use_attention:
             self.heads = heads
@@ -72,12 +76,26 @@ class HypergraphConv(MessagePassing):
 
         alpha = None
         if self.use_attention:
-            assert num_edges <= num_edges
             x = x.view(-1, self.heads, self.out_channels)
-            x_i, x_j = x[hyperedge_index[0]], x[hyperedge_index[1]]
+            edge_card = scatter_add(
+                x.new_ones(hyperedge_index.size(1), device=x.device),
+                hyperedge_index[1],
+                dim=0,
+                dim_size=num_edges,
+            ).clamp(min=1.0)
+            hyperedge_attr = scatter_add(
+                x[hyperedge_index[0]],
+                hyperedge_index[1],
+                dim=0,
+                dim_size=num_edges,
+            ) / edge_card.view(-1, 1, 1)
+            x_i, x_j = x[hyperedge_index[0]], hyperedge_attr[hyperedge_index[1]]
             alpha = (torch.cat([x_i, x_j], dim=-1) * self.att).sum(dim=-1)
             alpha = F.leaky_relu(alpha, self.negative_slope)
-            alpha = softmax(alpha, hyperedge_index[0], num_nodes=x.size(0))
+            if self.attention_mode == 'node':
+                alpha = softmax(alpha, hyperedge_index[1], num_nodes=num_edges)
+            else:
+                alpha = softmax(alpha, hyperedge_index[0], num_nodes=x.size(0))
             alpha = F.dropout(alpha, p=self.dropout, training=self.training)
 
         if not self.symdegnorm:
@@ -151,21 +169,42 @@ class HCHA(nn.Module):
         self.dropout = args.dropout  # Note that default is 0.6
         self.symdegnorm = args.HCHA_symdegnorm
         self.hidden_dim = args.MLP_hidden
+        self.use_attention = getattr(args, "HCHA_use_attention", False)
+        self.heads = getattr(args, "HCHA_heads", 8)
+        self.output_heads = getattr(args, "HCHA_output_heads", 1)
+        self.attention_mode = getattr(args, "HCHA_attention_mode", "edge")
+        self.negative_slope = getattr(args, "HCHA_negative_slope", 0.2)
 
 #       Note that add dropout to attention is default in the original paper
         self.convs = nn.ModuleList()
+
+        def layer(in_channels, out_channels, heads):
+            if self.use_attention:
+                if out_channels % heads != 0:
+                    raise ValueError(
+                        f"HCHA attention output dimension {out_channels} must be divisible by heads={heads}"
+                    )
+                return HypergraphConv(
+                    in_channels,
+                    out_channels // heads,
+                    self.symdegnorm,
+                    use_attention=True,
+                    heads=heads,
+                    concat=True,
+                    negative_slope=self.negative_slope,
+                    dropout=self.dropout,
+                    attention_mode=self.attention_mode,
+                )
+            return HypergraphConv(in_channels, out_channels, self.symdegnorm)
+
         if self.num_layers == 1:
-            self.convs.append(HypergraphConv(num_features,
-                               num_targets, self.symdegnorm))
+            self.convs.append(layer(num_features, num_targets, self.output_heads))
         else:
-            self.convs.append(HypergraphConv(num_features,
-                                            self.hidden_dim, self.symdegnorm))
+            self.convs.append(layer(num_features, self.hidden_dim, self.heads))
             for _ in range(self.num_layers-2):
-                self.convs.append(HypergraphConv(
-                    self.hidden_dim, self.hidden_dim, self.symdegnorm))
+                self.convs.append(layer(self.hidden_dim, self.hidden_dim, self.heads))
             # Output heads is set to 1 as default
-            self.convs.append(HypergraphConv(
-                self.hidden_dim, num_targets, self.symdegnorm))
+            self.convs.append(layer(self.hidden_dim, num_targets, self.output_heads))
 
     def reset_parameters(self):
         for conv in self.convs:

--- a/dhgbench/lib_models/HNN/preprocessing.py
+++ b/dhgbench/lib_models/HNN/preprocessing.py
@@ -31,13 +31,13 @@ def algo_preprocessing(data,args):
         data = hjrl_preprocessing(data,args)
     elif args.method == 'TMPHN':
         data = tmphn_preprocessing(data,args) 
-    elif args.method == 'DPHGNN':
+    elif args.method in ['DPHGNN','DPHGNN_Paper']:
         data = dphgnn_preprocessing(data,args) 
     elif args.method == 'EHNN':
         data = ehnn_preprocessing(data,args)
     elif args.method in ['PlainUnigencoder']:
         data =uni_expansion(data,args)
-    elif args.method == 'HyperGT':
+    elif args.method in ['HyperGT','HyperGT_Paper']:
         data = hypergt_preprocessing(data,args)
     elif args.method in ['CEGCN','CEGAT']:
         data = cegnn_preprocessing(data,args)
@@ -1062,7 +1062,7 @@ def hypergt_preprocessing(data, args, add_reverse=False, add_token_loops=True):
       - data.num_tokens = n + m
       - data.H:    [n, m] (float32, device)
       - data.adjs: [edge_index_token] (long, device)
-      - data.x:    [n+m, d]
+      - data.x:    [n+m, d], with hyperedge-token features controlled by args.hefeat
     """
     dev = torch.device(args.device)
 
@@ -1104,13 +1104,21 @@ def hypergt_preprocessing(data, args, add_reverse=False, add_token_loops=True):
 
     edge_index = edge_index.to(torch.long).to(dev)
 
-    # ---- 4) x -> [n, m]
+    # ---- 4) x -> [n + m, d]
     x = data.x
     if x.device != dev:
         x = x.to(dev)
     if x.size(0) == n:
-        pad = torch.zeros((m, x.size(1)), dtype=x.dtype, device=dev)
-        x = torch.cat([x, pad], dim=0)                       # [n+m, F]
+        hefeat = getattr(args, 'hefeat', 'zero')
+        if hefeat == 'mean':
+            hyperedge_x = torch_scatter.scatter_mean(x[v], e, dim=0, dim_size=m)
+        elif hefeat == 'zero':
+            hyperedge_x = torch.zeros((m, x.size(1)), dtype=x.dtype, device=dev)
+        elif hefeat == 'rand':
+            hyperedge_x = torch.rand((m, x.size(1)), dtype=x.dtype, device=dev)
+        else:
+            raise ValueError(f"Invalid HyperGT hyperedge feature mode: {hefeat}")
+        x = torch.cat([x, hyperedge_x], dim=0)                       # [n+m, F]
     elif x.size(0) != N:
         raise ValueError(f"data.x.shape[0]={x.size(0)} not match n(={n})/m(={m})")
 

--- a/dhgbench/lib_models/__init__.py
+++ b/dhgbench/lib_models/__init__.py
@@ -1,2 +1,2 @@
-_semi_methods_=['HGNN','HyperGCN','HCHA','HNHN','AllSetformer','AllDeepSets','UniGIN',
-          'LEGCN','HyperND','UniGCNII','EDHNN','PlainUnigencoder','HJRL','SheafHyperGNN','EHNN','TMPHN','PhenomNNS','PhenomNN','HyperGT','DPHGNN','TFHNN','CEGCN','CEGAT','MLP'] 
+_semi_methods_=['HGNN','HyperGCN','HCHA','HCHA_Paper','HNHN','AllSetformer','AllDeepSets','UniGIN',
+          'LEGCN','HyperND','UniGCNII','EDHNN','PlainUnigencoder','HJRL','SheafHyperGNN','EHNN','TMPHN','PhenomNNS','PhenomNN','HyperGT','HyperGT_Paper','DPHGNN','DPHGNN_Paper','TFHNN','CEGCN','CEGAT','MLP']

--- a/dhgbench/lib_utils/exp_agent.py
+++ b/dhgbench/lib_utils/exp_agent.py
@@ -236,7 +236,7 @@ def parse_model(args, data):
             model = SetGNN(data.num_features, num_targets, args, data.norm)
         else:
             model = SetGNN(data.num_features, num_targets, args)
-    elif args.method in ['HGNN','HCHA']:
+    elif args.method in ['HGNN','HCHA','HCHA_Paper']:
         model = HCHA(data.num_features, num_targets, args)
     elif args.method == 'HNHN':
         model = HNHN(data.num_features, num_targets, args)
@@ -264,7 +264,7 @@ def parse_model(args, data):
         model = PhenomNNS(data.num_features,num_targets,args)
     elif args.method == 'PhenomNN':
         model = PhenomNN(data.num_features,num_targets,args)
-    elif args.method == 'DPHGNN':
+    elif args.method in ['DPHGNN','DPHGNN_Paper']:
         model = DPHGNN(data.num_features,num_targets,args)
     elif args.method == 'PlainUnigencoder':
         model = PlainUnigencoder(data.num_features, num_targets, args)
@@ -272,7 +272,7 @@ def parse_model(args, data):
         model = TFHNN(data.num_features,num_targets,args)
     elif args.method == 'MLP':
         model = PlainMLP(data.num_features,num_targets,args)
-    elif args.method == 'HyperGT':
+    elif args.method in ['HyperGT','HyperGT_Paper']:
         model = HyperGT(data.num_features,num_targets,args)
     elif args.method == 'CEGCN':
         model = CEGCN(data.num_features,num_targets,args)

--- a/dhgbench/parameter_parser.py
+++ b/dhgbench/parameter_parser.py
@@ -12,6 +12,11 @@ def update_from_dict(obj, updates):
 
 # recommend hyperparameters here
 def method_config(args):
+    config_method = {
+        'HCHA_Paper': 'hcha',
+        'HyperGT_Paper': 'hypergt',
+        'DPHGNN_Paper': 'dphgnn',
+    }.get(args.method, args.method.lower())
 
     if args.is_default:
         config_name = 'default'
@@ -20,8 +25,24 @@ def method_config(args):
     try:
         # conf_dt = json.load(open(f"{os.path.join('./', 'lib_configs', args.method.lower(), config_name)}.json")) 
         task_prefix=args.task_type.split('_')[0]+'_yamls'
-        conf_dt = yaml.safe_load(open(f"{os.path.join('./', 'lib_yamls', task_prefix,'config_'+args.method.lower())}.yaml"))[config_name] 
+        conf_dt = yaml.safe_load(open(f"{os.path.join('./', 'lib_yamls', task_prefix,'config_'+config_method)}.yaml"))[config_name]
         update_from_dict(args, conf_dt)
+        if args.method == 'HCHA_Paper':
+            args.HCHA_use_attention = True
+            args.HCHA_symdegnorm = False
+            args.HCHA_heads = 8
+            args.HCHA_output_heads = 1
+            args.HCHA_attention_mode = 'edge'
+        if args.method == 'HyperGT_Paper':
+            args.pe = 'HEPEHtEPE'
+            args.hefeat = 'mean'
+            args.use_edge_loss = True
+            args.rb_order = 0
+            args.rb_trans = 'sigmoid'
+            args.use_gumbel = True
+        if args.method == 'DPHGNN_Paper':
+            args.DPHGNN_dff_mode = 'paper'
+            args.mediator = True
     except:
         print('No config file found or error in json format, please use method_config(args)')
 
@@ -61,7 +82,7 @@ def set_task_args(args):
 
         if args.method in ['HyperND']:
             args.add_self_loop=True 
-        elif args.method in ['DPHGNN','LEGCN','PhenomNN','HJRL','TFHNN','HNHN','AllSetformer'] and args.dname in ['pokec']:
+        elif args.method in ['DPHGNN','DPHGNN_Paper','LEGCN','PhenomNN','HJRL','TFHNN','HNHN','AllSetformer'] and args.dname in ['pokec']:
             args.add_self_loop=True
         elif args.method in ['TMPHN']:
             if args.dname in ['pokec']:
@@ -161,6 +182,12 @@ def parameter_parser():
 
     # Choose std for synthetic feature noise
     parser.add_argument('--feature_noise', default='0.6', type=str)
+    parser.add_argument('--HCHA_use_attention', default=False, type=str2bool)
+    parser.add_argument('--HCHA_heads', default=8, type=int)
+    parser.add_argument('--HCHA_output_heads', default=1, type=int)
+    parser.add_argument('--HCHA_attention_mode', default='edge', choices=['node', 'edge'])
+    parser.add_argument('--HCHA_negative_slope', default=0.2, type=float)
+    parser.add_argument('--DPHGNN_dff_mode', default='attention', choices=['attention', 'paper'])
     
     parser.set_defaults(add_self_loop=False)
     parser.set_defaults(exclude_self=False)

--- a/tests/test_paper_discrepancy_fixes.py
+++ b/tests/test_paper_discrepancy_fixes.py
@@ -1,0 +1,208 @@
+from pathlib import Path
+from types import SimpleNamespace
+import os
+import sys
+
+import torch
+from torch_geometric.data import Data
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DHGBENCH_ROOT = REPO_ROOT / "dhgbench"
+sys.path.insert(0, str(DHGBENCH_ROOT))
+
+
+def _configured_args(method, task_type="node_cls", dname="cora"):
+    from parameter_parser import method_config, parameter_parser
+
+    old_argv = sys.argv[:]
+    old_cwd = os.getcwd()
+    try:
+        os.chdir(DHGBENCH_ROOT)
+        sys.argv = [
+            "test",
+            "--method",
+            method,
+            "--task_type",
+            task_type,
+            "--dname",
+            dname,
+            "--is_default",
+            "True",
+            "--device",
+            "cpu",
+        ]
+        return method_config(parameter_parser())
+    finally:
+        sys.argv = old_argv
+        os.chdir(old_cwd)
+
+
+def test_hcha_paper_uses_attention_branch_and_runs_forward():
+    from lib_models.HNN.hgnn import HCHA
+
+    args = _configured_args("HCHA_Paper")
+    args.All_num_layers = 2
+    args.MLP_hidden = 16
+    args.dropout = 0.0
+
+    model = HCHA(num_features=4, num_targets=3, args=args)
+    model.eval()
+
+    assert all(conv.use_attention for conv in model.convs)
+    assert model.convs[0].heads == 8
+    assert model.convs[0].attention_mode == "edge"
+    assert model.convs[-1].heads == 1
+
+    data = Data(
+        x=torch.arange(16, dtype=torch.float32).view(4, 4) / 10.0,
+        hyperedge_index=torch.tensor(
+            [
+                [0, 1, 2, 1, 2, 3, 0, 3],
+                [0, 0, 1, 1, 2, 2, 3, 4],
+            ],
+            dtype=torch.long,
+        ),
+    )
+    out, edge_embed = model(data)
+
+    assert out.shape == (4, 3)
+    assert edge_embed.shape == (5, 3)
+    assert torch.isfinite(out).all()
+    assert torch.isfinite(edge_embed).all()
+
+
+def test_hypergt_paper_preprocessing_uses_mean_hyperedge_features():
+    from lib_models.HNN.preprocessing import hypergt_preprocessing
+
+    args = _configured_args("HyperGT_Paper")
+    assert args.hefeat == "mean"
+    assert args.pe == "HEPEHtEPE"
+    assert args.use_edge_loss is True
+
+    original_x = torch.tensor(
+        [
+            [1.0, 2.0],
+            [3.0, 4.0],
+            [5.0, 8.0],
+        ]
+    )
+    data = Data(
+        x=original_x.clone(),
+        hyperedge_index=torch.tensor(
+            [
+                [0, 1, 1, 2],
+                [5, 5, 6, 6],
+            ],
+            dtype=torch.long,
+        ),
+        num_nodes=3,
+    )
+
+    out = hypergt_preprocessing(data, args, add_reverse=False, add_token_loops=True)
+
+    expected_hyperedge_x = torch.tensor(
+        [
+            [2.0, 3.0],
+            [4.0, 6.0],
+        ]
+    )
+    assert out.num_tokens == 5
+    assert out.H.shape == torch.Size([3, 2])
+    assert torch.allclose(out.x[:3], original_x)
+    assert torch.allclose(out.x[3:], expected_hyperedge_x)
+
+    loops = out.adjs[0][:, -out.num_tokens :]
+    assert torch.equal(loops[0], torch.arange(out.num_tokens))
+    assert torch.equal(loops[1], torch.arange(out.num_tokens))
+
+
+def test_dphgnn_paper_alias_selects_paper_dff():
+    from lib_models.HNN.dphgnn import DFF, DPHGNN, PaperDFF
+
+    args = _configured_args("DPHGNN_Paper")
+    assert args.DPHGNN_dff_mode == "paper"
+    assert args.mediator is True
+
+    args.expan_dim = 4
+    args.taa_spatial_dim = 4
+    args.taa_spectral_dim = 4
+    args.spectral_embed_dim = 4
+    args.fc_dim = 4
+    args.dff_MLP_hidden = 4
+    args.dff_num_layers = 1
+    args.cg_num_layer = args.hg_num_layer = args.sg_num_layer = 1
+    args.cg_MLP_hidden = args.hg_MLP_hidden = args.sg_MLP_hidden = 4
+    args.cg_dropout = args.hg_dropout = args.sg_dropout = 0.0
+    args.num_heads = 1
+    args.chunk_size = -1
+    args.device = "cpu"
+
+    paper_model = DPHGNN(num_features=3, num_targets=2, args=args)
+    assert isinstance(paper_model.dff_layer, PaperDFF)
+
+    args.DPHGNN_dff_mode = "attention"
+    plain_model = DPHGNN(num_features=3, num_targets=2, args=args)
+    assert isinstance(plain_model.dff_layer, DFF)
+
+
+def test_paper_dphgnn_conv_matches_additive_dff_equation():
+    from lib_models.HNN.dphgnn import PaperDPHGNNConv
+
+    args = SimpleNamespace(expan_dim=3)
+    conv = PaperDPHGNNConv(in_channels=2, out_channels=2, args=args, drop_rate=0.0)
+    conv.eval()
+
+    with torch.no_grad():
+        conv.skip_proj.weight.zero_()
+        conv.skip_proj.bias.zero_()
+        conv.msg_proj.weight.copy_(torch.eye(2))
+        conv.msg_proj.bias.zero_()
+        conv.star_proj.weight.copy_(
+            torch.tensor(
+                [
+                    [1.0, 0.0, 0.0],
+                    [0.0, 1.0, 0.0],
+                ]
+            )
+        )
+        conv.star_proj.bias.zero_()
+
+    x = torch.tensor(
+        [
+            [1.0, 0.0],
+            [0.0, 2.0],
+            [3.0, 1.0],
+        ]
+    )
+    s_features = torch.tensor(
+        [
+            [2.0, 4.0, 99.0],
+            [6.0, 8.0, 99.0],
+        ]
+    )
+    hyperedge_index = torch.tensor(
+        [
+            [0, 1, 1, 2],
+            [0, 0, 1, 1],
+        ],
+        dtype=torch.long,
+    )
+
+    out = conv(x, hyperedge_index, s_features)
+
+    degree_v = torch.tensor([1.0, 2.0, 1.0])
+    degree_e = torch.tensor([2.0, 2.0])
+    dv_inv_sqrt = degree_v.pow(-0.5)
+    de_inv = degree_e.pow(-1.0)
+    v, e = hyperedge_index
+
+    node_to_edge = torch.zeros(2, 2)
+    node_to_edge.index_add_(0, e, x[v] * dv_inv_sqrt[v].unsqueeze(-1))
+    star_term = s_features[:, :2] * de_inv.unsqueeze(-1)
+    fused_edge = node_to_edge + star_term
+
+    expected = torch.zeros(3, 2)
+    expected.index_add_(0, v, fused_edge[e] * de_inv[e].unsqueeze(-1))
+
+    assert torch.allclose(out, expected, atol=1e-6)


### PR DESCRIPTION
## Summary

This PR adds explicit paper-compatible execution paths for three models where the current implementation either could not exercise the paper branch correctly or silently ignored paper-configured behavior.

The existing method names remain behavior-compatible by default:

- `HCHA`
- `HyperGT`
- `DPHGNN`

New opt-in aliases expose the paper-compatible paths without changing historical benchmark results:

- `HCHA_Paper`
- `HyperGT_Paper`
- `DPHGNN_Paper`

Each alias reuses the existing YAML config for the base model, then applies only the settings required to select the paper path.

## What Changed

### HCHA

`HCHA_Paper` now enables the attention branch while plain `HCHA` remains non-attentive by default.

The attention implementation previously indexed node features with hyperedge ids when constructing attention pairs. That fails when `num_hyperedges > num_nodes` and does not represent hyperedge structure correctly. The paper path now computes hyperedge-side attention features as the mean of incident node features, then uses those structural hyperedge features in the attention calculation.

Added parser/config support for:

- `HCHA_use_attention`
- `HCHA_heads`
- `HCHA_output_heads`
- `HCHA_attention_mode`
- `HCHA_negative_slope`

### HyperGT

`HyperGT_Paper` now forces the paper-style preprocessing settings, including:

- `hefeat='mean'`
- `pe='HEPEHtEPE'`
- `use_edge_loss=True`

The preprocessing code previously zero-padded hyperedge-token features even when configs requested `hefeat: mean`. `hypergt_preprocessing` now honors:

- `hefeat='mean'`: mean of incident node features
- `hefeat='zero'`: previous zero-padding behavior
- `hefeat='rand'`: random hyperedge-token features

Plain `HyperGT` keeps its existing default behavior unless configured otherwise.

### DPHGNN

`DPHGNN_Paper` now selects a paper-equation Dynamic Feature Fusion path via:

- `DPHGNN_dff_mode='paper'`

Plain `DPHGNN` continues to use the existing attention-concat DFF implementation through the default:

- `DPHGNN_dff_mode='attention'`

The paper path adds:

- `PaperDFF`
- `PaperDPHGNNConv`
- final paper-style node-level hypergraph output layer

## Why Aliases?

The aliases make the corrected paper-compatible behavior available without changing the outputs or training behavior of existing method names. That keeps old benchmark runs reproducible while allowing users to explicitly request the implementation path that matches the papers.

## Tests

```text
python -m pytest -q tests/test_paper_discrepancy_fixes.py
....                                                                     [100%]
4 passed in 3.72s
```

```text
python -m pytest -q
............                                                           [100%]
12 passed, 2 subtests passed in 4.59s
```

```text
git diff --check
passed
```
