### PR TITLE
[codex] Fix node classification output dimension

### DIFF
--- a/dhgbench/parameter_parser.py
+++ b/dhgbench/parameter_parser.py
@@ -124,7 +124,7 @@ def parameter_parser():
     parser.add_argument('--display_step', type=int, default=20)
     parser.add_argument('--eval_verbose',default=True)
     
-    parser.add_argument('--embedding_mode',default=True,type=bool) 
+    parser.add_argument('--embedding_mode', default=False, type=str2bool)
     parser.add_argument('--embedding_hidden',default=128,type=int) 
     
     parser.add_argument('--normtype', default='all_one') # ['all_one','deg_half_sym']


### PR DESCRIPTION
## Summary

This PR fixes the default output dimension used by node-classification models.

`parse_model()` uses `args.embedding_hidden` when `args.embedding_mode` is true, otherwise it uses `data.num_classes`. The parser currently defaults `embedding_mode` to true, so normal node-classification runs build classifiers with `embedding_hidden` output logits instead of one logit per class.

## Why

This can break datasets whose label count exceeds `embedding_hidden`. For example, Trivago has 160 classes while most node YAML entries use `embedding_hidden: 128`, which can trigger an `NLLLoss` target-range error. For datasets with fewer than 128 classes, the run may not crash but still trains with extra unused output classes.

Edge prediction and hypergraph classification still explicitly set `embedding_mode = True` before constructing encoders, so their intended encoder behavior is preserved.

## Validation

- `python -m py_compile dhgbench/parameter_parser.py`
- Parser smoke check:
  - default `embedding_mode` is `False`
  - `--embedding_mode True` parses as `True`
  - `--embedding_mode False` parses as `False`
