### PR TITLE
[codex] Fix LEGCN line expansion preprocessing

### DIFF
--- a/dhgbench/lib_models/HNN/preprocessing.py
+++ b/dhgbench/lib_models/HNN/preprocessing.py
@@ -591,13 +591,15 @@ def line_expansion(data,args):
     hyperedge_index=copy.deepcopy(data.hyperedge_index)
     hyperedge_index = hyperedge_index.to('cpu')
     V, E = hyperedge_index
-    E = E + V.max() # [V | E]
+    num_nodes = int(data.num_nodes)
+    E = E + num_nodes # [V | E]
     num_ne_pairs = hyperedge_index.shape[1]
-    V_plus_E = E.max() + 1
-    L1 = torch.stack([torch.arange(V.shape[0], device=V.device), V], -1)
-    L2 = torch.stack([torch.arange(E.shape[0], device=E.device), E], -1)
-    L = torch.cat([L1, L2], -1) # [2, |V| + |E|]
-    L_T = torch.stack([L[1], L[0]], 0) # [2, |V| + |E|]
+    V_plus_E = int(E.max().item()) + 1 if E.numel() > 0 else num_nodes
+    pair_ids = torch.arange(num_ne_pairs, device=V.device)
+    L1 = torch.stack([pair_ids, V], 0)
+    L2 = torch.stack([pair_ids, E], 0)
+    L = torch.cat([L1, L2], 1) # [2, 2 * |V-E incidence pairs|]
+    L_T = torch.stack([L[1], L[0]], 0) # [2, 2 * |V-E incidence pairs|]
     ones = torch.ones(L.shape[1], device=L.device)
     adj, value = torch_sparse.spspmm(L, ones, L_T, ones, num_ne_pairs, V_plus_E, num_ne_pairs, coalesced=True)
     adj, value = torch_sparse.coalesce(adj, value, num_ne_pairs, num_ne_pairs, op="add")


### PR DESCRIPTION
## Summary

Fix LEGCN line expansion preprocessing so the sparse matrix multiplication receives a valid COO index.

## Root cause

`line_expansion` constructed `L1` and `L2` as row-wise `[incidence_id, node_or_edge_id]` tables and concatenated them along the last dimension. That produced a tensor shaped like `[num_incidence_pairs, 4]`, but `torch_sparse.spspmm` expects COO indices shaped `[2, nnz]`.

The previous hyperedge offset also used `V.max()`, which can collide with the last node id and is wrong when not every node appears in the incidence. The offset should be `data.num_nodes`.

## Changes

- Use `data.num_nodes` as the hyperedge-node offset.
- Build `L` as a two-row COO index with shape `[2, 2 * num_incidence_pairs]`.
- Keep the downstream `spspmm` and `coalesce` behavior unchanged.

## Validation

- `/opt/conda/bin/python -m py_compile dhgbench/lib_models/HNN/preprocessing.py`
- Focused `line_expansion` smoke test on a small incidence example where `num_nodes > V.max() + 1`.
